### PR TITLE
Fix crash in Cronet_UploadDataSinkImpl::Close() due to use-after-free

### DIFF
--- a/examples/1/main.go
+++ b/examples/1/main.go
@@ -65,6 +65,7 @@ func main() {
 	engineParams.SetProxyServer(proxyArg.String())
 
 	t := cronet.NewCronetTransport(engineParams, true)
+	defer t.Close()
 	ConfigureClientCertificate(&t.Engine, certPath, keyPath, []string{urlArg.Host, proxyArg.Host})
 
 	client := &http.Client{

--- a/examples/1/main.go
+++ b/examples/1/main.go
@@ -65,7 +65,6 @@ func main() {
 	engineParams.SetProxyServer(proxyArg.String())
 
 	t := cronet.NewCronetTransport(engineParams, true)
-	defer t.Close()
 	ConfigureClientCertificate(&t.Engine, certPath, keyPath, []string{urlArg.Host, proxyArg.Host})
 
 	client := &http.Client{

--- a/transport.go
+++ b/transport.go
@@ -220,7 +220,6 @@ func (r *urlResponse) OnRedirectReceived(self URLRequestCallback, request URLReq
 		r.response.Header.Set(header.Name(), header.Value())
 	}
 	r.response.Body = io.NopCloser(io.MultiReader())
-	r.uploadComplete.Wait()
 	request.Cancel()
 	r.readyToRead.Signal()
 }


### PR DESCRIPTION
Fixed race condition due to async nature of Cronet Go Executor when _UploadDataSink_ closure has been executed after URL request is destroyed.

1.  `cronet::Cronet_UploadDataSinkImpl::Close()` is run in Go Executor provided in transport `requestParams.SetUploadDataExecutor(t.Executor)`.
2. Due to async nature of Go Executor the closure sometimes fires after URL request is complete and all other runnables are done. When it is complete the request is destroyed in `transport.close()`.
3. _UploadDataSink_ instance is kept in URL request object, so when the request is destroyed, the sink is destroyed as well. And invoking a method on a destroyed object results in crash.

The solution is based on the fact that when _UploadDataSink_ is closed, in invokes closure of _UploadDataProvider_, where we can signal to the rest of the program that the request can be safely destroyed.

The issue was emulated locally then fix verified.