### PR TITLE
Separate cronet transport and executor creation and usage

### DIFF
--- a/executor_impl.go
+++ b/executor_impl.go
@@ -11,6 +11,11 @@ import (
 	"unsafe"
 )
 
+var (
+	executorAccess sync.RWMutex
+	executors      = make(map[uintptr]ExecutorExecuteFunc)
+)
+
 func NewExecutor(executeFunc ExecutorExecuteFunc) Executor {
 	ptr := C.Cronet_Executor_CreateWith((*[0]byte)(C.cronetExecutorExecute))
 	executorAccess.Lock()
@@ -24,15 +29,6 @@ func (e Executor) Destroy() {
 	executorAccess.Lock()
 	delete(executors, uintptr(unsafe.Pointer(e.ptr)))
 	executorAccess.Unlock()
-}
-
-var (
-	executorAccess sync.RWMutex
-	executors      map[uintptr]ExecutorExecuteFunc
-)
-
-func init() {
-	executors = make(map[uintptr]ExecutorExecuteFunc)
 }
 
 //export cronetExecutorExecute


### PR DESCRIPTION
In essence, cronet transport and executors are two separate entities, so removed association between executors creation and new transport creation. Executor essentially provides callback for certain tasks to be executed on caller thread and technically can be shared between multiple cronet transports if needed.  So with this change, moved executors creation and destruction with lifetime of the  runtime process, and now can be shared between multiple transports if needed.