### PR TITLE
Set headers in go response structure via Add method to support supplying multiple Set-Cookie headers

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -215,7 +215,7 @@ func (r *urlResponse) OnRedirectReceived(self URLRequestCallback, request URLReq
 	headerLen := info.HeaderSize()
 	for i := 0; i < headerLen; i++ {
 		header := info.HeaderAt(i)
-		r.response.Header.Set(header.Name(), header.Value())
+		r.response.Header.Add(header.Name(), header.Value())
 	}
 	r.response.Body = io.NopCloser(io.MultiReader())
 	request.Cancel()
@@ -237,7 +237,7 @@ func (r *urlResponse) OnResponseStarted(self URLRequestCallback, request URLRequ
 			resetContentLength = true
 			continue
 		}
-		r.response.Header.Set(header.Name(), header.Value())
+		r.response.Header.Add(header.Name(), header.Value())
 	}
 	if resetContentLength {
 		r.response.Uncompressed = true


### PR DESCRIPTION
Set headers via Add rather than Set of http.Headers, because Set drops values of headers with same key which is needed use case for **_Set-Cookie_** headers.
HTTP Response can have one more more headers value for single key, so [Add](https://pkg.go.dev/net/http#Header.Add) method which supports appending value to existing header values should be used rather than Set which unsets the previous value 