### PR TITLE
Utilization for cronet operation results being propagated from Cronet native side

### DIFF
--- a/http_util.go
+++ b/http_util.go
@@ -1,0 +1,36 @@
+package cronet
+
+func isTokenChar(c byte) bool {
+	return !(c >= 0x7F || c <= 0x20 || c == '(' || c == ')' || c == '<' ||
+		c == '>' || c == '@' || c == ',' || c == ';' || c == ':' ||
+		c == '\\' || c == '"' || c == '/' || c == '[' || c == ']' ||
+		c == '?' || c == '=' || c == '{' || c == '}')
+}
+
+func isToken(str string) bool {
+	if len(str) == 0 {
+		return false
+	}
+	for _, c := range str {
+		if !isTokenChar(byte(c)) {
+			return false
+		}
+	}
+	return true
+}
+
+func IsValidHeaderName(value string) bool {
+	return isToken(value)
+}
+
+func IsValidHeaderValue(value string) bool {
+	if len(value) == 0 {
+		return false
+	}
+	for _, c := range value {
+		if c == '\x00' || c == '\r' || c == '\n' {
+			return false
+		}
+	}
+	return true
+}

--- a/transport.go
+++ b/transport.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"log"
 	"net"
 	"net/http"
 	"net/textproto"
@@ -17,8 +18,11 @@ import (
 
 var asyncExecutor Executor
 var syncExecutor Executor
+var logger *log.Logger
 
 func init() {
+	logger = log.New(os.Stderr, "", 0)
+
 	asyncExecutor = NewExecutor(func(executor Executor, command Runnable) {
 		go func() {
 			command.Run()
@@ -213,6 +217,7 @@ func (r *urlResponse) OnRedirectReceived(self URLRequestCallback, request URLReq
 	r.response.Status = info.StatusText()
 	r.response.StatusCode = info.StatusCode()
 	headerLen := info.HeaderSize()
+	logger.Println("OnRedirectReceived : Adding headers via Add method and not Set!!")
 	for i := 0; i < headerLen; i++ {
 		header := info.HeaderAt(i)
 		r.response.Header.Add(header.Name(), header.Value())
@@ -228,6 +233,7 @@ func (r *urlResponse) OnResponseStarted(self URLRequestCallback, request URLRequ
 	headerLen := info.HeaderSize()
 
 	resetContentLength := false
+	logger.Println("OnResponseStarted : Adding headers via Add method and not Set!!")
 	for i := 0; i < headerLen; i++ {
 		header := info.HeaderAt(i)
 		// Drop Content-Encoding header if body has been decompressed already


### PR DESCRIPTION
- Added changes to utilize and propagate errors for any unsuccessful cronet operation on based of cronet results
- Added changes to check and avoid headers the way cronet checks on native side, and added helper logs for it 