### PR TITLE
Added check to skip adding headers in Cronet request if empty value

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -82,6 +82,9 @@ func (t *RoundTripper) RoundTrip(request *http.Request) (*http.Response, error) 
 	}
 	for key, values := range request.Header {
 		for _, value := range values {
+			if len(value) == 0 {
+				continue
+			}
 			header := NewHTTPHeader()
 			header.SetName(key)
 			header.SetValue(value)


### PR DESCRIPTION
We have removed this check in last [PR](https://github.com/weblifeio/cronet-go/pull/12/files#diff-5982a4ca350449c8a5deba675bc4bc4bb0f1823c45e6c7ba0076cc6b159fef8f)
But this seems needed after some testing to avoid invalid null and empty header values, so adding it back